### PR TITLE
mask password and private key

### DIFF
--- a/app/sftp.js
+++ b/app/sftp.js
@@ -9,7 +9,7 @@ const connect = async (server) => {
   if (sftpConfig.managedGatewayEnabled && server === MANAGED_GATEWAY) {
     if (sftpConfig.debug) {
       console.log('Connecting to Managed Gateway')
-      console.log({ ...sftpConfig.managedGateway, privateKey: 'HIDDEN' })
+      console.log({ ...sftpConfig.managedGateway, password: 'HIDDEN', privateKey: 'HIDDEN' })
     }
     managedGateway = new Client()
     await managedGateway.connect(sftpConfig.managedGateway)
@@ -17,7 +17,7 @@ const connect = async (server) => {
   if (sftpConfig.callistoEnabled && server === CALLISTO) {
     if (sftpConfig.debug) {
       console.log('Connecting to Callisto')
-      console.log({ ...sftpConfig.callisto, privateKey: 'HIDDEN' })
+      console.log({ ...sftpConfig.callisto, password: 'HIDDEN', privateKey: 'HIDDEN' })
     }
     callisto = new Client()
     await callisto.connect(sftpConfig.callisto)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-pay-gateway",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "Managed Gateway integration",
   "homepage": "https://github.com/DEFRA/ffc-pay-gateway",
   "main": "app/index.js",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/DOC-1454

Required as Callisto now utilises password instead of private key.