### PR TITLE
Altering all references of Callisto to Trader in gateway service

### DIFF
--- a/app/config/scheme.js
+++ b/app/config/scheme.js
@@ -1,6 +1,6 @@
 const Joi = require('joi')
 const { SFI, SFI_PILOT, LUMP_SUMS, CS, BPS, FDMR, ES, FC, IMPS, SFI23, DPS, DELINKED, SFI_EXPANDED } = require('../constants/schemes')
-const { MANAGED_GATEWAY, CALLISTO } = require('../constants/servers')
+const { MANAGED_GATEWAY, TRADER } = require('../constants/servers')
 
 const schema = Joi.object({
   sfi: Joi.object({
@@ -101,7 +101,7 @@ const schema = Joi.object({
       inbound: Joi.array().items(Joi.string()).default([/^CTL_FIN_IMPS_A[P|R]_\d*\.INT$/]),
       outbound: Joi.array().items(Joi.string()).default([/^CTL_RET_IMPS_A[P|R]_\d*\.INT$/])
     }),
-    server: Joi.string().default(CALLISTO),
+    server: Joi.string().default(TRADER),
     directories: Joi.object({
       inbound: Joi.string().required(),
       outbound: Joi.string().required()
@@ -125,7 +125,7 @@ const schema = Joi.object({
       inbound: Joi.array().items(Joi.string()).default([/^CTL_BGAN.*.OUT$/]),
       outbound: Joi.array().items(Joi.string()).default([/^CTL_BGAN.*.ack$/])
     }),
-    server: Joi.string().default(CALLISTO),
+    server: Joi.string().default(TRADER),
     directories: Joi.object({
       inbound: Joi.string().required(),
       outbound: Joi.string().required()

--- a/app/config/sftp.js
+++ b/app/config/sftp.js
@@ -3,7 +3,7 @@ const Joi = require('joi')
 const schema = Joi.object({
   debug: Joi.boolean().default(false),
   managedGatewayEnabled: Joi.boolean().default(true),
-  callistoEnabled: Joi.boolean().default(true),
+  traderEnabled: Joi.boolean().default(true),
   managedGateway: Joi.object({
     host: Joi.string().required(),
     port: Joi.number().integer().default(22),
@@ -11,7 +11,7 @@ const schema = Joi.object({
     password: Joi.string().optional().allow(''),
     privateKey: Joi.string().optional().allow('')
   }).required(),
-  callisto: Joi.object({
+  trader: Joi.object({
     host: Joi.string().required(),
     port: Joi.number().integer().default(22),
     username: Joi.string().required(),
@@ -23,7 +23,7 @@ const schema = Joi.object({
 const config = {
   debug: process.env.SFTP_DEBUG,
   managedGatewayEnabled: process.env.SFTP_MANAGED_GATEWAY_ENABLED,
-  callistoEnabled: process.env.SFTP_CALLISTO_ENABLED,
+  traderEnabled: process.env.SFTP_TRADER_ENABLED,
   managedGateway: {
     host: process.env.SFTP_MANAGED_GATEWAY_HOST,
     port: process.env.SFTP_MANAGED_GATEWAY_PORT,
@@ -31,12 +31,12 @@ const config = {
     password: process.env.SFTP_MANAGED_GATEWAY_PASSWORD,
     privateKey: process.env.SFTP_MANAGED_GATEWAY_PRIVATE_KEY
   },
-  callisto: {
-    host: process.env.SFTP_CALLISTO_HOST,
-    port: process.env.SFTP_CALLISTO_PORT,
-    username: process.env.SFTP_CALLISTO_USERNAME,
-    password: process.env.SFTP_CALLISTO_PASSWORD,
-    privateKey: process.env.SFTP_CALLISTO_PRIVATE_KEY
+  trader: {
+    host: process.env.SFTP_TRADER_HOST,
+    port: process.env.SFTP_TRADER_PORT,
+    username: process.env.SFTP_TRADER_USERNAME,
+    password: process.env.SFTP_TRADER_PASSWORD,
+    privateKey: process.env.SFTP_TRADER_PRIVATE_KEY
   }
 }
 
@@ -50,11 +50,11 @@ if (result.error) {
 
 if (result.value.debug) {
   result.value.managedGateway.debug = (message) => console.log(message)
-  result.value.callisto.debug = (message) => console.log(message)
+  result.value.trader.debug = (message) => console.log(message)
 }
 
 if (process.env.NODE_ENV === 'production') {
-  result.value.callisto.algorithms = { kex: ['diffie-hellman-group14-sha256'] }
+  result.value.trader.algorithms = { kex: ['diffie-hellman-group14-sha256'] }
   result.value.managedGateway.algorithms = { kex: ['diffie-hellman-group1-sha1'] }
 }
 

--- a/app/constants/servers.js
+++ b/app/constants/servers.js
@@ -1,4 +1,4 @@
 module.exports = {
   MANAGED_GATEWAY: 'Managed Gateway',
-  CALLISTO: 'Callisto'
+  TRADER: 'Trader'
 }

--- a/app/sftp.js
+++ b/app/sftp.js
@@ -1,9 +1,9 @@
 const Client = require('ssh2-sftp-client')
-const { MANAGED_GATEWAY, CALLISTO } = require('./constants/servers')
+const { MANAGED_GATEWAY, TRADER } = require('./constants/servers')
 const { sftpConfig } = require('./config')
 
 let managedGateway
-let callisto
+let trader
 
 const connect = async (server) => {
   if (sftpConfig.managedGatewayEnabled && server === MANAGED_GATEWAY) {
@@ -14,13 +14,13 @@ const connect = async (server) => {
     managedGateway = new Client()
     await managedGateway.connect(sftpConfig.managedGateway)
   }
-  if (sftpConfig.callistoEnabled && server === CALLISTO) {
+  if (sftpConfig.traderEnabled && server === TRADER) {
     if (sftpConfig.debug) {
-      console.log('Connecting to Callisto')
-      console.log({ ...sftpConfig.callisto, password: 'HIDDEN', privateKey: 'HIDDEN' })
+      console.log('Connecting to Trader')
+      console.log({ ...sftpConfig.trader, password: 'HIDDEN', privateKey: 'HIDDEN' })
     }
-    callisto = new Client()
-    await callisto.connect(sftpConfig.callisto)
+    trader = new Client()
+    await trader.connect(sftpConfig.trader)
   }
 }
 
@@ -29,8 +29,8 @@ const disconnect = async (server) => {
     if (sftpConfig.managedGatewayEnabled && server === MANAGED_GATEWAY) {
       await managedGateway.end()
     }
-    if (sftpConfig.callistoEnabled && server === CALLISTO) {
-      await callisto.end()
+    if (sftpConfig.traderEnabled && server === TRADER) {
+      await trader.end()
     }
   } catch (err) {
     console.error(`Unable to disconnect: ${err}`)
@@ -61,7 +61,7 @@ const getClient = (server) => {
   if (server === MANAGED_GATEWAY) {
     return managedGateway
   }
-  return callisto
+  return trader
 }
 
 const getControlFiles = async (transfer) => {

--- a/app/transfer/get-active-transfers.js
+++ b/app/transfer/get-active-transfers.js
@@ -1,6 +1,6 @@
 const { sftpConfig } = require('../config')
 const { INBOUND, OUTBOUND } = require('../constants/directions')
-const { MANAGED_GATEWAY, CALLISTO } = require('../constants/servers')
+const { MANAGED_GATEWAY, TRADER } = require('../constants/servers')
 const { getSchemeTransfers } = require('./get-scheme-transfers')
 
 const getActiveTransfers = () => {
@@ -8,8 +8,8 @@ const getActiveTransfers = () => {
   if (sftpConfig.managedGatewayEnabled) {
     activeServers.push(MANAGED_GATEWAY)
   }
-  if (sftpConfig.callistoEnabled) {
-    activeServers.push(CALLISTO)
+  if (sftpConfig.traderEnabled) {
+    activeServers.push(TRADER)
   }
   const inboundTransfers = getSchemeTransfers(activeServers, INBOUND)
   const outboundTransfers = getSchemeTransfers(activeServers, OUTBOUND)

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       AZURE_STORAGE_CONNECTION_STRING: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://ffc-pay-batch-azurite:10000/devstoreaccount1;
       SFTP_MANAGED_GATEWAY_PASSWORD: password
-      SFTP_CALLISTO_PASSWORD: password
+      SFTP_TRADER_PASSWORD: password
 
   ffc-pay-batch-azurite:
     labels:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,9 +14,9 @@ services:
       SFTP_MANAGED_GATEWAY_HOST: ffc-pay-gateway-sftp
       SFTP_MANAGED_GATEWAY_USERNAME: ffc
       SFTP_MANAGED_GATEWAY_PRIVATE_KEY: ${SFTP_MANAGED_GATEWAY_PRIVATE_KEY}
-      SFTP_CALLISTO_HOST: ffc-pay-gateway-sftp
-      SFTP_CALLISTO_USERNAME: ffc
-      SFTP_CALLISTO_PRIVATE_KEY: ${SFTP_CALLISTO_PRIVATE_KEY}
+      SFTP_TRADER_HOST: ffc-pay-gateway-sftp
+      SFTP_TRADER_USERNAME: ffc
+      SFTP_TRADER_PRIVATE_KEY: ${SFTP_TRADER_PRIVATE_KEY}
       SFI_INBOUND_DIRECTORY: local-directory/inbound
       SFI_PILOT_INBOUND_DIRECTORY: local-directory/inbound
       LUMP_SUMS_INBOUND_DIRECTORY: local-directory/inbound

--- a/helm/ffc-pay-gateway/templates/config-map.yaml
+++ b/helm/ffc-pay-gateway/templates/config-map.yaml
@@ -12,8 +12,8 @@ data:
   SFTP_DEBUG: {{ quote .Values.container.sftpDebug }}
   SFTP_MANAGED_GATEWAY_HOST: {{ quote .Values.container.sftpManagedGatewayHost }}
   SFPT_MANAGED_GATEWAY_PORT: {{ quote .Values.container.sftpManagedGatewayPort }}
-  SFTP_CALLISTO_HOST: {{ quote .Values.container.sftpCallistoHost }}
-  SFTP_CALLISTO_PORT: {{ quote .Values.container.sftpCallistoPort }}
+  SFTP_TRADER_HOST: {{ quote .Values.container.sftpTraderHost }}
+  SFTP_TRADER_PORT: {{ quote .Values.container.sftpTraderPort }}
   {{- if and (.Values.environmentCode) (eq (.Values.environmentCode | toString ) "prd") }}
   SFI_INBOUND_DIRECTORY: {{ quote .Values.container.sfiInboundDirectory }}
   SFI_PILOT_INBOUND_DIRECTORY: {{ quote .Values.container.sfiPilotInboundDirectory }}
@@ -48,7 +48,7 @@ data:
   DPS_INBOUND_DIRECTORY: {{ quote .Values.container.dpsInboundDirectory }}
   DPS_OUTBOUND_DIRECTORY: {{ quote .Values.container.dpsOutboundDirectory }}
   SFTP_MANAGED_GATEWAY_ENABLED: {{ quote .Values.container.sftpManagedGatewayEnabled }}
-  SFTP_CALLISTO_ENABLED: {{ quote .Values.container.sftpCallistoEnabled }}
+  SFTP_TRADER_ENABLED: {{ quote .Values.container.sftpTraderEnabled }}
   SFI_ENABLED: {{ quote .Values.container.sfiEnabled }}
   SFI_PILOT_ENABLED: {{ quote .Values.container.sfiPilotEnabled }}
   LUMP_SUMS_ENABLED: {{ quote .Values.container.lumpSumsEnabled }}

--- a/helm/ffc-pay-gateway/templates/container-secret.yaml
+++ b/helm/ffc-pay-gateway/templates/container-secret.yaml
@@ -4,12 +4,12 @@ stringData:
   {{- if .Values.appInsights.connectionString }}
   APPINSIGHTS_CONNECTIONSTRING: {{ quote .Values.appInsights.connectionString }}
   {{- end }}
-  SFTP_CALLISTO_USERNAME: {{ quote .Values.container.sftpCallistoUsername }}
-  {{- if .Values.container.sftpCallistoPassword }}
-  SFTP_CALLISTO_PASSWORD: {{ quote .Values.container.sftpCallistoPassword }}
+  SFTP_TRADER_USERNAME: {{ quote .Values.container.sftpTraderUsername }}
+  {{- if .Values.container.sftpTraderPassword }}
+  SFTP_TRADER_PASSWORD: {{ quote .Values.container.sftpTraderPassword }}
   {{- end }}
-  {{- if .Values.container.sftpCallistoPrivateKey }}
-  SFTP_CALLISTO_PRIVATE_KEY: {{ quote .Values.container.sftpCallistoPrivateKey }}
+  {{- if .Values.container.sftpTraderPrivateKey }}
+  SFTP_TRADER_PRIVATE_KEY: {{ quote .Values.container.sftpTraderPrivateKey }}
   {{- end }}
   SFTP_MANAGED_GATEWAY_USERNAME: {{ quote .Values.container.sftpManagedGatewayUsername }}
   {{- if .Values.container.sftpManagedGatewayPassword }}

--- a/helm/ffc-pay-gateway/values.yaml
+++ b/helm/ffc-pay-gateway/values.yaml
@@ -35,11 +35,11 @@ container:
   sftpManagedGatewayUsername: ffc
   sftpManagedGatewayPassword:
   sftpManagedGatewayPrivateKey:
-  sftpCallistoHost: callisto
-  sftpCallistoPort: 22
-  sftpCallistoUsername: ffc
-  sftpCallistoPassword:
-  sftpCallistoPrivateKey:
+  sftpTraderHost: trader
+  sftpTraderPort: 22
+  sftpTraderUsername: ffc
+  sftpTraderPassword:
+  sftpTraderPrivateKey:
   sfiInboundDirectory: /opt/cap_prod_data/DAX/out/Int_725
   sfiPilotInboundDirectory: /opt/cap_prod_data/DAX/out/Int_725
   lumpSumsInboundDirectory: /opt/cap_prod_data/DAX/out/Int_725
@@ -59,7 +59,7 @@ container:
   sfiExpandedInboundDirectory: /opt/cap_prod_data/DAX/out/Int_725
   sftpDebug: false
   sftpManagedGatewayEnabled: true
-  sftpCallistoEnabled: true
+  sftpTraderEnabled: true
   sfiEnabled: true
   sfiPilotEnabled: true
   lumpSumsEnabled: true

--- a/scripts/start
+++ b/scripts/start
@@ -27,7 +27,7 @@ if [ ! -f .ssh/ssh_host_rsa_key ]; then
 fi
 
 export SFTP_MANAGED_GATEWAY_PRIVATE_KEY=$(cat .ssh/ssh_host_rsa_key)
-export SFTP_CALLISTO_PRIVATE_KEY=$(cat .ssh/ssh_host_rsa_key)
+export SFTP_TRADER_PRIVATE_KEY=$(cat .ssh/ssh_host_rsa_key)
 
 docker compose down
 

--- a/test/integration/local/outbound.test.js
+++ b/test/integration/local/outbound.test.js
@@ -10,7 +10,7 @@ const { storageConfig, schemeConfig } = require('../../../app/config')
 
 const { start } = require('../../../app/polling')
 
-const { MANAGED_GATEWAY, CALLISTO } = require('../../../app/constants/servers')
+const { MANAGED_GATEWAY, TRADER } = require('../../../app/constants/servers')
 
 let blobServiceClient
 let daxContainer
@@ -48,7 +48,7 @@ describe('process outbound files', () => {
 
   afterEach(async () => {
     await disconnect(MANAGED_GATEWAY)
-    await disconnect(CALLISTO)
+    await disconnect(TRADER)
   })
 
   test('should process ES outbound files', async () => {
@@ -81,8 +81,8 @@ describe('process outbound files', () => {
 
     await start()
 
-    await connect(CALLISTO)
-    const fileList = await getFiles(CALLISTO)
+    await connect(TRADER)
+    const fileList = await getFiles(TRADER)
     expect(fileList.find(x => x.name === IMPS_RETURN_FILENAME)).toBeDefined()
     expect(fileList.find(x => x.name === IMPS_RETURN_CONTROL_FILENAME)).toBeDefined()
   })
@@ -93,8 +93,8 @@ describe('process outbound files', () => {
 
     await start()
 
-    await connect(CALLISTO)
-    const fileList = await getFiles(CALLISTO)
+    await connect(TRADER)
+    const fileList = await getFiles(TRADER)
     expect(fileList.find(x => x.name === DPS_RETURN_FILENAME)).toBeDefined()
     expect(fileList.find(x => x.name === DPS_RETURN_CONTROL_FILENAME)).toBeDefined()
   })

--- a/test/unit/transfer/get-active-transfers.test.js
+++ b/test/unit/transfer/get-active-transfers.test.js
@@ -4,7 +4,7 @@ const { getSchemeTransfers } = require('../../../app/transfer/get-scheme-transfe
 const { sftpConfig } = require('../../../app/config')
 
 const { INBOUND, OUTBOUND } = require('../../../app/constants/directions')
-const { MANAGED_GATEWAY, CALLISTO } = require('../../../app/constants/servers')
+const { MANAGED_GATEWAY, TRADER } = require('../../../app/constants/servers')
 
 const { getActiveTransfers } = require('../../../app/transfer/get-active-transfers')
 
@@ -12,64 +12,64 @@ describe('get active transfers', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     sftpConfig.managedGatewayEnabled = true
-    sftpConfig.callistoEnabled = true
+    sftpConfig.traderEnabled = true
 
     getSchemeTransfers.mockReturnValue([])
   })
 
   test('should return empty array if no active servers or schemes', () => {
     sftpConfig.managedGatewayEnabled = false
-    sftpConfig.callistoEnabled = false
+    sftpConfig.traderEnabled = false
     const result = getActiveTransfers()
     expect(result).toEqual([])
   })
 
   test('should get inbound scheme transfers with no active servers if no active servers', () => {
     sftpConfig.managedGatewayEnabled = false
-    sftpConfig.callistoEnabled = false
+    sftpConfig.traderEnabled = false
     getActiveTransfers()
     expect(getSchemeTransfers).toHaveBeenCalledWith([], INBOUND)
   })
 
   test('should get outbound scheme transfers with no active servers if no active servers', () => {
     sftpConfig.managedGatewayEnabled = false
-    sftpConfig.callistoEnabled = false
+    sftpConfig.traderEnabled = false
     getActiveTransfers()
     expect(getSchemeTransfers).toHaveBeenCalledWith([], OUTBOUND)
   })
 
   test('should get inbound scheme transfers with all severs if all active', () => {
     getActiveTransfers()
-    expect(getSchemeTransfers).toHaveBeenCalledWith([MANAGED_GATEWAY, CALLISTO], INBOUND)
+    expect(getSchemeTransfers).toHaveBeenCalledWith([MANAGED_GATEWAY, TRADER], INBOUND)
   })
 
   test('should get outbound scheme transfers with all severs if all active', () => {
     getActiveTransfers()
-    expect(getSchemeTransfers).toHaveBeenCalledWith([MANAGED_GATEWAY, CALLISTO], OUTBOUND)
+    expect(getSchemeTransfers).toHaveBeenCalledWith([MANAGED_GATEWAY, TRADER], OUTBOUND)
   })
 
   test('should get inbound scheme transfers with managed gateway if only managed gateway active', () => {
-    sftpConfig.callistoEnabled = false
+    sftpConfig.traderEnabled = false
     getActiveTransfers()
     expect(getSchemeTransfers).toHaveBeenCalledWith([MANAGED_GATEWAY], INBOUND)
   })
 
   test('should get outbound scheme transfers with managed gateway if only managed gateway active', () => {
-    sftpConfig.callistoEnabled = false
+    sftpConfig.traderEnabled = false
     getActiveTransfers()
     expect(getSchemeTransfers).toHaveBeenCalledWith([MANAGED_GATEWAY], OUTBOUND)
   })
 
-  test('should get inbound scheme transfers with callisto if only callisto active', () => {
+  test('should get inbound scheme transfers with trader if only trader active', () => {
     sftpConfig.managedGatewayEnabled = false
     getActiveTransfers()
-    expect(getSchemeTransfers).toHaveBeenCalledWith([CALLISTO], INBOUND)
+    expect(getSchemeTransfers).toHaveBeenCalledWith([TRADER], INBOUND)
   })
 
-  test('should get outbound scheme transfers with callisto if only callisto active', () => {
+  test('should get outbound scheme transfers with trader if only trader active', () => {
     sftpConfig.managedGatewayEnabled = false
     getActiveTransfers()
-    expect(getSchemeTransfers).toHaveBeenCalledWith([CALLISTO], OUTBOUND)
+    expect(getSchemeTransfers).toHaveBeenCalledWith([TRADER], OUTBOUND)
   })
 
   test('should return inbound and outbound transfers', () => {

--- a/test/unit/transfer/get-scheme-transfers.test.js
+++ b/test/unit/transfer/get-scheme-transfers.test.js
@@ -1,5 +1,5 @@
 const { INBOUND, OUTBOUND } = require('../../../app/constants/directions')
-const { MANAGED_GATEWAY, CALLISTO } = require('../../../app/constants/servers')
+const { MANAGED_GATEWAY, TRADER } = require('../../../app/constants/servers')
 
 jest.mock('../../../app/config/scheme', () => ({
   scheme1: {
@@ -20,7 +20,7 @@ jest.mock('../../../app/config/scheme', () => ({
     fileMasks: {
       inbound: ['mask5']
     },
-    server: 'Callisto',
+    server: 'Trader',
     directories: {
       inbound: 'directory3'
     },
@@ -31,7 +31,7 @@ jest.mock('../../../app/config/scheme', () => ({
     fileMasks: {
       inbound: ['mask6']
     },
-    server: 'Callisto',
+    server: 'Trader',
     directories: {
       inbound: 'directory4'
     },
@@ -63,23 +63,23 @@ describe('get scheme transfers', () => {
   })
 
   test('should return empty array if no file masks for direction', () => {
-    const result = getSchemeTransfers([CALLISTO], OUTBOUND)
+    const result = getSchemeTransfers([TRADER], OUTBOUND)
     expect(result).toEqual([])
   })
 
   test('should only return active schemes', () => {
-    const result = getSchemeTransfers([CALLISTO], INBOUND)
+    const result = getSchemeTransfers([TRADER], INBOUND)
     expect(result[0].fileMask).toBe('mask5')
     expect(result.length).toBe(1)
   })
 
   test('should add direction to scheme', () => {
-    const result = getSchemeTransfers([CALLISTO], INBOUND)
+    const result = getSchemeTransfers([TRADER], INBOUND)
     expect(result[0].direction).toBe(INBOUND)
   })
 
   test('should add file mask as top level property', () => {
-    const result = getSchemeTransfers([CALLISTO], INBOUND)
+    const result = getSchemeTransfers([TRADER], INBOUND)
     expect(result[0].fileMask).toBe('mask5')
   })
 })


### PR DESCRIPTION
Minor changes made to various files within the gateway service, removing the legacy naming conventions for "Callisto" to "Trader". 

No alterations to how the application functions have been made, simply just variable renaming.